### PR TITLE
Add --device=all for webcam access

### DIFF
--- a/edu.mit.Scratch.yaml
+++ b/edu.mit.Scratch.yaml
@@ -14,6 +14,7 @@ finish-args:
   - '--socket=x11'
   - '--socket=pulseaudio'
   - '--device=dri'
+  - '--device=all'
   - '--filesystem=home'
   - '--talk-name=org.freedesktop.Notifications'
 modules:


### PR DESCRIPTION
Scratch comes with an extension that uses your webcam. However, without
this switch it cannot see any webcams.